### PR TITLE
Repaint scene view when testing

### DIFF
--- a/Assets/Plugins/StatefulUI/Editor/ReferenceInspectors/StatesInspector.cs
+++ b/Assets/Plugins/StatefulUI/Editor/ReferenceInspectors/StatesInspector.cs
@@ -88,6 +88,7 @@ namespace StatefulUI.Editor.ReferenceInspectors
             if (GUILayout.Button("Test", EditorStyles.miniButton, GUILayout.Width(TestButtonWidth)))
             {
                 stateInspector?.Apply();
+                SceneView.RepaintAll();
             }
             
             GUILayout.Space(10);

--- a/Assets/Plugins/StatefulUI/Editor/Tree/StateTreeEditor.cs
+++ b/Assets/Plugins/StatefulUI/Editor/Tree/StateTreeEditor.cs
@@ -649,6 +649,7 @@ namespace StatefulUI.Editor.Tree
                 if (info.IsDoubleClick)
                 {
                     _view.ApplyState(State);
+                    SceneView.RepaintAll();
                     VisualizeStateApplying();
                 }
             }


### PR DESCRIPTION
# Bug description
When testing states outside of play mode, certain state changes do not refresh/repaint the SceneView or GameView.
One example is states that only change the color of an Image. 

This PR crudely calls `SceneView.RepaintAll` after clicking the "Test" buttons or double clicking a state in the tree view.