### PR TITLE
Scroll Wheel Click to Pan Tree View

### DIFF
--- a/Assets/Plugins/StatefulUI/Editor/Tree/StateTreeEditor.cs
+++ b/Assets/Plugins/StatefulUI/Editor/Tree/StateTreeEditor.cs
@@ -453,7 +453,7 @@ namespace StatefulUI.Editor.Tree
                 }
             }
 
-            if (evnt.button == 1 && !_isRightButtonClicking)
+            if (evnt.button == 1 || evnt.button == 2 && !_isRightButtonClicking)
             {
                 switch (evnt.type)
                 {


### PR DESCRIPTION
Currently, to pan the view in the Tree View, one must right click and drag.

This was a little bit confusing to those who normally click the scroll wheel to pan (as is the case in the Scene view, for example).

This PR adds the ability to pan by clicking the scroll wheel and dragging. 